### PR TITLE
fix: Upgrade automated test scripts with additional validations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 #
 # File:        travis.yml
-# Description: Define the continuous integration environment and rules (including tests) to be 
+# Description: Define the continuous integration environment and rules (including tests) to be
 #              executed whenever changes are promoted to the "development" branch in GitHub.
 #              At this time TravisCI is used only for continuous testing, but the longer term
-#              vision is to run this whenever changes are promoted to the "development" 
+#              vision is to run this whenever changes are promoted to the "development"
 #              branch and to deploy to the Production runtime environment as long as all
 #              tests pass.
 #
@@ -16,6 +16,7 @@ cache:
     - node_modules
 script:
 #  - yarn lint
-  - npm run test
+  - npm run test-valid
+  - npm run test-invalid
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-### 0.2.0 - 03/28/2018
-- Added support for the new `events` segment to the `repo` context 
- 
+### 0.3.0 - 03/28/2018
+- Added support for the new `events` segment to the `repo` context
+
 ### 0.1.2 - 03/14/2018
 - Update change log format
 
@@ -10,7 +10,7 @@
 
 - Renamed GitAClue.js to gitaclue.js and moved to the root of the package to eliminate need to specify import/require path to `gitaclue/src/GitAClue`
 - Replaced 'Release Notes' section in readme with 'Change Log'
-  
+
 ### 0.1.0 - 03/14/2018
 
 - Initial release

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-all": "mocha --reporter min --require ./test/helper.js '+(test|validate)/**/*Spec.js'",
     "test-valid": "mocha --require ./test/helper.js './test/testUI_valid.Spec.js'",
     "test-invalid": "mocha --require ./test/helper.js './test/testUI_invalid.Spec.js'",
-    "test-one": "mocha --require ./test/helper.js './test/testGitAClue_single.Spec.js'",
+    "test-one": "mocha --require ./test/helper.js './test/testUI_single.Spec.js'",
     "test-repo": "mocha --require ./test/helper.js './test/testRepo.Spec.js'"
   },
   "repository": {

--- a/test/testUI_single.Spec.js
+++ b/test/testUI_single.Spec.js
@@ -17,9 +17,10 @@ describe('Test gitAClue.js functions', () => {
       ];
       const result = await gitAClue.get(option);
       console.log('result: ', result);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).repo.owner, 'jdmedlock');
       assert.notEqual(JSON.parse(result).repo.events.length, 0, 'number of events > 0');
     });
-    
+
   });
 });

--- a/test/testUI_valid.Spec.js
+++ b/test/testUI_valid.Spec.js
@@ -8,13 +8,14 @@ describe('Test gitAClue.js functions', () => {
     it('should return true for valid options - context and segments', async () => {
       const option = [
         {
-          context: 'repo', 
-          contextOwner: 'jdmedlock', 
-          contextName: 'GitAClue', 
+          context: 'repo',
+          contextOwner: 'jdmedlock',
+          contextName: 'GitAClue',
           segments: ['contributors'],
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).repo.name, 'GitAClue');
     });
 
@@ -33,6 +34,7 @@ describe('Test gitAClue.js functions', () => {
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).repo.name, 'GitAClue');
       assert.equal(JSON.parse(result).user.name, 'jdmedlock');
     });
@@ -47,16 +49,18 @@ describe('Test gitAClue.js functions', () => {
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).repo.owner, 'jdmedlock');
       assert.equal(JSON.parse(result).repo.name, 'GitAClue');
       assert.notEqual(JSON.parse(result).repo.events.length, 0, 'number of events > 0');
     });
-    
+
     it('should return true for a valid context - no segments', async () => {
       const option = [
         { context: 'user', contextOwner: '', contextName: 'jdmedlock' },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).user.name, 'jdmedlock');
     });
 
@@ -70,6 +74,7 @@ describe('Test gitAClue.js functions', () => {
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).user.name, 'jdmedlock');
     });
 
@@ -83,6 +88,7 @@ describe('Test gitAClue.js functions', () => {
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).user.name, 'jdmedlock');
     });
 
@@ -96,6 +102,7 @@ describe('Test gitAClue.js functions', () => {
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).user.name, 'jdmedlock');
     });
 
@@ -109,6 +116,7 @@ describe('Test gitAClue.js functions', () => {
         },
       ];
       const result = await gitAClue.get(option);
+      assert.equal(JSON.parse(result).error, undefined);
       assert.equal(JSON.parse(result).user.name, 'jdmedlock');
     });
   });


### PR DESCRIPTION
Upgrade automated test scripts with additional validations
Configure TravisCI to run the test-valid and test-invalid scripts when PR'ing
Update the version number of the current release in the change log

Resolves: N/a
See also: N/a